### PR TITLE
Add tree response to array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -282,7 +282,7 @@ client.on("message", (message: Message) => {
 
   // add response for tshirt
   if (isTee(message)) {
-    message.channel.send("TREES > TEES");
+    responses.push("TREES > TEES");
     toSay = true;
     timer = Date.now();
   }


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

This change fixes the "trees > tees" response by pushing it into the `responses` array instead of sending it directly.

This way, instead of sending the responses like this:
![image](https://user-images.githubusercontent.com/49726028/98393442-e2bbd380-201e-11eb-8452-88bc0aaac7e7.png)

the "tees" response will be in the same message as all the other responses.
